### PR TITLE
Automate triage and harden Codex workflows

### DIFF
--- a/.github/workflows/codex-autofix.yml
+++ b/.github/workflows/codex-autofix.yml
@@ -33,26 +33,38 @@ jobs:
         with:
           ref: ${{ env.FAILED_HEAD_SHA }}
           fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: '20'
-          cache: 'npm'
+          bun-version: latest
       - name: Install dependencies
-        run: |
-          if [ -f package-lock.json ]; then npm ci; else npm i; fi
+        run: bun install --frozen-lockfile
       - name: Run Codex
-        uses: openai/codex-action@main
+        uses: openai/codex-action@v1
         id: codex
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           prompt: >-
-            You are working in a Node.js monorepo with Jest tests and GitHub Actions. Read the repository,
-            run the test suite, identify the minimal change needed to make all tests pass, implement only that change,
-            and stop. Do not refactor unrelated code or files. Keep changes small and surgical.
-          codex_args: '["--config","sandbox_mode=\"workspace-write\""]'
-      - name: Verify tests
-        run: npm test --silent
+            You are working in a Bun + TypeScript monorepo with Foundry contracts and GitHub Actions.
+            Read the repository, run the Bun lint and build scripts as well as `forge test`,
+            identify the minimal change needed to make these commands succeed, implement only that change, and stop.
+            Do not refactor unrelated code or files. Keep changes small and surgical.
+          codex_args: '["--config","sandbox_mode=\"workspace-write\"","--config","allow_network=\"false\""]'
+      - name: Setup Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+      - name: Verify lint
+        run: bun run lint
+      - name: Verify build
+        env:
+          VITE_PUBLIC_APP_ID: test-app
+          VITE_PUBLIC_CONTRACT_ADDRESS: 0x0000000000000000000000000000000000000000
+        run: bun run build
+      - name: Install Foundry dependencies
+        working-directory: contracts
+        run: forge install
+      - name: Verify contracts
+        working-directory: contracts
+        run: forge test --silent
       - name: Create pull request with fixes
         if: success()
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,7 +1,12 @@
 name: Perform a code review when a pull request is created.
 on:
   pull_request:
-    types: [opened]
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+      - edited
 
 jobs:
   codex:
@@ -22,6 +27,33 @@ jobs:
             ${{ github.event.pull_request.base.ref }} \
             +refs/pull/${{ github.event.pull_request.number }}/head
 
+      - name: Summarise changed files
+        id: changed-files
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ github.token }}
+          result-encoding: string
+          script: |
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              },
+            );
+
+            const summary = files
+              .map((file) => {
+                const changeCount =
+                  typeof file.changes === 'number' ? `, ${file.changes} changes` : '';
+                return `- ${file.filename} (${file.status}${changeCount})`;
+              })
+              .join('\n');
+
+            return summary || 'No file changes reported.';
+
       # If you want Codex to build and run code, install any dependencies that
       # need to be downloaded before the "Run Codex" step because Codex's
       # default sandbox disables network access.
@@ -35,6 +67,9 @@ jobs:
             This is PR #${{ github.event.pull_request.number }} for ${{ github.repository }}.
             Base SHA: ${{ github.event.pull_request.base.sha }}
             Head SHA: ${{ github.event.pull_request.head.sha }}
+
+            Changed files:
+            ${{ steps.changed-files.outputs.result }}
 
             Review ONLY the changes introduced by the PR.
             Suggest any improvements, potential bugs, or issues.

--- a/.github/workflows/codex-triage.yml
+++ b/.github/workflows/codex-triage.yml
@@ -1,0 +1,232 @@
+name: Codex Auto Triage
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+      - synchronize
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  triage_issue:
+    if: github.event_name == 'issues' && secrets.OPENAI_API_KEY != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare issue context
+        id: issue-context
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const body = context.payload.issue.body ?? 'No description provided.';
+            const labels = (context.payload.issue.labels || []).map((label) => label.name);
+            core.setOutput('body', body);
+            core.setOutput('labels', labels.length ? labels.join(', ') : 'none');
+      - name: Run Codex triage
+        id: codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt: |
+            You are the autonomous triage bot for the repository ${{ github.repository }}.
+            Analyse the following GitHub issue and decide which of the predefined labels should be applied.
+            Respond with a compact JSON object that follows this exact TypeScript type without extra commentary:
+            {
+              "labels": string[],
+              "comment": string
+            }
+
+            Use only labels from this list:
+              - type:bug
+              - type:feature
+              - type:question
+              - type:maintenance
+              - area:frontend
+              - area:contracts
+              - area:automation
+              - priority:low
+              - priority:medium
+              - priority:high
+              - status:needs-info
+              - status:ready
+
+            Always include at most one label per namespace (e.g. only one priority:*).
+            Add "status:needs-info" and ask clarifying questions in the comment when the report is unclear or missing reproduction steps.
+            If no action is needed, return an empty array for labels and an empty string for comment.
+
+            Issue title: ${{ github.event.issue.title }}
+            Issue body:
+            ---
+            ${{ steps.issue-context.outputs.body }}
+            ---
+
+            Existing labels on the issue: ${{ steps.issue-context.outputs.labels }}
+      - name: Apply triage decisions
+        if: steps.codex.outputs.final-message != ''
+        uses: actions/github-script@v8
+        env:
+          CODEX_JSON: ${{ steps.codex.outputs.final-message }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            if (!process.env.CODEX_JSON) {
+              core.info('No Codex decision to apply.');
+              return;
+            }
+
+            let parsed;
+            try {
+              parsed = JSON.parse(process.env.CODEX_JSON);
+            } catch (error) {
+              core.warning(`Could not parse Codex response: ${error}`);
+              core.debug(process.env.CODEX_JSON);
+              return;
+            }
+            const labels = Array.isArray(parsed.labels)
+              ? parsed.labels.filter(Boolean)
+              : [];
+            const comment = typeof parsed.comment === 'string' ? parsed.comment.trim() : '';
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                labels,
+              });
+            }
+
+            if (comment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body: comment,
+              });
+            }
+
+  triage_pr:
+    if: github.event_name == 'pull_request' && secrets.OPENAI_API_KEY != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gather changed files
+        id: changed-files
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ github.token }}
+          result-encoding: string
+          script: |
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              },
+            );
+
+            return files
+              .map((file) => {
+                const changeCount =
+                  typeof file.changes === 'number' ? `, ${file.changes} changes` : '';
+                return `${file.filename} (${file.status}${changeCount})`;
+              })
+              .join('\n');
+      - name: Run Codex triage
+        id: codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt: |
+            You are the autonomous PR triage bot for ${{ github.repository }}.
+            Based on the pull request description and changed files, decide which labels should be applied
+            and whether a maintainer-facing comment is needed.
+            Respond with JSON matching this type and do not include any other text:
+            {
+              "labels": string[],
+              "comment": string
+            }
+
+            Allowed labels:
+              - status:needs-review
+              - status:needs-info
+              - status:ready
+              - scope:frontend
+              - scope:contracts
+              - scope:tooling
+              - scope:automation
+              - priority:low
+              - priority:medium
+              - priority:high
+              - tests:missing
+              - tests:included
+
+            Apply exactly one status:* label.
+            If the PR does not touch test files and should include tests, add "tests:missing".
+            If it contains changes under contracts/ ensure you also set scope:contracts, etc.
+            Leave the comment empty when no additional guidance is necessary.
+
+            Pull request title: ${{ github.event.pull_request.title }}
+            Pull request body:
+            ---
+            ${{ github.event.pull_request.body }}
+            ---
+
+            Changed files:
+            ${{ steps.changed-files.outputs.result || 'No files detected.' }}
+      - name: Apply PR triage decisions
+        if: steps.codex.outputs.final-message != ''
+        uses: actions/github-script@v8
+        env:
+          CODEX_JSON: ${{ steps.codex.outputs.final-message }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            if (!process.env.CODEX_JSON) {
+              core.info('No Codex decision to apply.');
+              return;
+            }
+
+            let parsed;
+            try {
+              parsed = JSON.parse(process.env.CODEX_JSON);
+            } catch (error) {
+              core.warning(`Could not parse Codex response: ${error}`);
+              core.debug(process.env.CODEX_JSON);
+              return;
+            }
+            const labels = Array.isArray(parsed.labels)
+              ? parsed.labels.filter(Boolean)
+              : [];
+            const comment = typeof parsed.comment === 'string' ? parsed.comment.trim() : '';
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels,
+              });
+            }
+
+            if (comment) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: comment,
+              });
+            }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install Dependencies
         run: bun install --frozen-lockfile
 
+      - name: Run Biome (lint & format check)
+        run: bunx --bun biome ci --reporter github
+
       - name: Run ESLint
         run: bun run lint:ts -- --format github
 


### PR DESCRIPTION
## Summary
- add a Codex-driven triage workflow to auto-label issues and pull requests
- enhance Codex review automation with richer triggers and change summaries
- align auto-fix and lint workflows with Bun/Foundry tooling and Biome formatting checks

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e4070c265c8320a9f908c221cebadf