### PR TITLE
Add Civilisation branding SVG asset pack

### DIFF
--- a/assets/branding/README.md
+++ b/assets/branding/README.md
@@ -1,0 +1,29 @@
+# Civilisation Branding Assets
+
+This folder contains SVG assets that follow the Civilisation brand direction (ancient power + digital precision) for the World App MiniKit experience.
+
+## App Icon Concepts
+
+| File | Concept | Notes |
+| --- | --- | --- |
+| `app-icon-crown.svg` | Glowing Crown | Golden crown rising from stone with cyan rune glow and Cinzel "C" monogram. |
+| `app-icon-shield.svg` | Digital Shield | Split medieval shield blending steel texture with cyan blockchain veins and engraved "CIVIL". |
+| `app-icon-citadel.svg` | Rising Citadel | Stylised fortress silhouette with cyan data beams and gold highlights, optimised for small sizes. |
+
+## Store Preview / Hero Images
+
+Each hero graphic uses the blue/gold/cyan palette with serif display typography and geometric UI accents.
+
+1. `preview-build-your-kingdom.svg` — City-building overview with resource overlays. Caption: *From humble village to mighty empire.*
+2. `preview-rule-through-strategy.svg` — Tactical planner with glowing battle paths. Caption: *Plan. Conquer. Expand.*
+3. `preview-on-the-world-chain.svg` — Worldcoin-inspired coin close-up emphasising on-chain ownership. Caption: *Own your progress, on-chain.*
+4. `preview-epic-alliances.svg` — Allied armies converging beneath radiant banners. Caption: *Unite or be conquered.*
+5. `preview-your-legacy-awaits.svg` — Hero overlooking a digital-medieval horizon. Caption: *CIVIL — Build a world that remembers you.*
+
+## Optional Motion Ideas
+
+* **Animated Logo Reveal**: Use the crown or shield icon, animate gold particles converging while cyan runes ignite. Layered in After Effects using these SVGs as vector sources.
+* **Splash Screen**: Slow zoom on the chosen icon with subtle cyan pulse (approx. 8-second loop).
+* **Loading Spinner**: Rotate the coin center from `preview-on-the-world-chain.svg` or animate the crown gem as a glowing indicator.
+
+> Tip: Because all assets are vector-based SVGs, they can be exported to PNG/WebP at any required resolution for MiniKit distribution.

--- a/assets/branding/app-icon-citadel.svg
+++ b/assets/branding/app-icon-citadel.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="sky" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#14173a" />
+      <stop offset="100%" stop-color="#2b2f77" />
+    </linearGradient>
+    <linearGradient id="ground" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1e202f" />
+      <stop offset="100%" stop-color="#0f1018" />
+    </linearGradient>
+    <linearGradient id="gold" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f0d39d" />
+      <stop offset="100%" stop-color="#d8b36f" />
+    </linearGradient>
+    <radialGradient id="beam" cx="0.5" cy="1" r="0.7">
+      <stop offset="0%" stop-color="#00e0ff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#00e0ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="url(#sky)" />
+  <g opacity="0.6">
+    <path d="M48 196c24-28 52-44 80-44s56 16 80 44" fill="none" stroke="#00e0ff" stroke-width="2" stroke-dasharray="6 6" />
+  </g>
+  <path d="M0 196h256v60H0z" fill="url(#ground)" />
+  <g transform="translate(64 64)">
+    <rect x="48" y="84" width="32" height="44" fill="#2b2f77" stroke="#00e0ff" stroke-width="2" />
+    <path d="M32 116h64v44H32z" fill="#1a1d35" stroke="#00c4e3" stroke-width="2" />
+    <path d="M16 108h96v8H16z" fill="#d8b36f" opacity="0.75" />
+    <path d="M32 52h64v64H32z" fill="#232649" stroke="#3b3f7f" stroke-width="2" />
+    <path d="M48 24h32v28H48z" fill="#20244a" stroke="#4c5193" stroke-width="2" />
+    <path d="M64 0l28 24H36z" fill="url(#gold)" />
+    <path d="M32 44h64" stroke="#00e0ff" stroke-width="3" opacity="0.55" />
+    <g stroke="#d8b36f" stroke-width="4" stroke-linecap="round">
+      <path d="M16 148h96" />
+      <path d="M40 160h48" />
+    </g>
+    <g stroke="#00e0ff" stroke-width="2" opacity="0.4">
+      <path d="M64 24v96" stroke-dasharray="4 4" />
+      <path d="M48 64h32" />
+      <path d="M40 76h48" />
+    </g>
+  </g>
+  <path d="M128 64l64 132" stroke="#00e0ff" stroke-width="3" stroke-opacity="0.35" stroke-dasharray="8 10" />
+  <path d="M128 64l-64 132" stroke="#00e0ff" stroke-width="3" stroke-opacity="0.35" stroke-dasharray="8 10" />
+  <ellipse cx="128" cy="72" rx="52" ry="44" fill="url(#beam)" opacity="0.65" />
+  <path d="M80 212h96" stroke="#f0d39d" stroke-width="6" stroke-linecap="round" />
+  <text x="128" y="232" text-anchor="middle" font-family="'Cinzel', serif" font-size="34" fill="#f0d39d">CIVIL</text>
+</svg>

--- a/assets/branding/app-icon-crown.svg
+++ b/assets/branding/app-icon-crown.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1d235c" />
+      <stop offset="100%" stop-color="#2b2f77" />
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.35" r="0.55">
+      <stop offset="0%" stop-color="#00e0ff" stop-opacity="0.75" />
+      <stop offset="100%" stop-color="#00e0ff" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="crownMetal" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f0d39d" />
+      <stop offset="50%" stop-color="#d8b36f" />
+      <stop offset="100%" stop-color="#b2853e" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#0f122d" flood-opacity="0.65" />
+    </filter>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="url(#bg)" />
+  <rect width="256" height="256" rx="56" fill="url(#glow)" />
+  <g filter="url(#shadow)">
+    <path fill="url(#crownMetal)" stroke="#f3dcb0" stroke-width="4" d="M64 156l12-64 36 40 16-68 16 68 36-40 12 64z" />
+  </g>
+  <path d="M68 184h120" stroke="#00e0ff" stroke-width="4" stroke-linecap="round" opacity="0.5" />
+  <path d="M92 196h72" stroke="#00e0ff" stroke-width="3" stroke-linecap="round" opacity="0.35" />
+  <path d="M128 112l18-18 18 18-18 18z" fill="#00e0ff" opacity="0.9" transform="scale(0.9) translate(14,15)" />
+  <path d="M128 112l12-12 12 12-12 12z" fill="#182045" opacity="0.65" transform="scale(0.75) translate(43,47)" />
+  <path d="M40 232h176" stroke="#17192f" stroke-opacity="0.65" stroke-width="12" stroke-linecap="round" />
+  <path d="M40 224h176" stroke="#2f336c" stroke-width="8" stroke-linecap="round" opacity="0.7" />
+  <g opacity="0.4" stroke="#00e0ff" stroke-width="2" stroke-linecap="round">
+    <path d="M32 64h24" />
+    <path d="M200 48h24" />
+    <path d="M54 104h18" />
+    <path d="M184 92h18" />
+  </g>
+  <g opacity="0.25" stroke="#00e0ff" stroke-width="1.5">
+    <path d="M52 60l20 20" />
+    <path d="M188 60l20 20" />
+  </g>
+  <text x="128" y="226" text-anchor="middle" fill="#d8b36f" font-family="'Cinzel', serif" font-size="42">C</text>
+</svg>

--- a/assets/branding/app-icon-shield.svg
+++ b/assets/branding/app-icon-shield.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="shieldBg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#232323" />
+      <stop offset="100%" stop-color="#2b2f77" />
+    </linearGradient>
+    <linearGradient id="steel" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#6d7385" />
+      <stop offset="100%" stop-color="#2f3548" />
+    </linearGradient>
+    <linearGradient id="light" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#00e0ff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#007a9d" stop-opacity="0.6" />
+    </linearGradient>
+    <linearGradient id="engrave" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#d8b36f" />
+      <stop offset="100%" stop-color="#8a642e" />
+    </linearGradient>
+    <clipPath id="shieldClip">
+      <path d="M128 32l72 32v76c0 52-40 86-72 96-32-10-72-44-72-96V64z" />
+    </clipPath>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="url(#shieldBg)" />
+  <g clip-path="url(#shieldClip)">
+    <rect x="32" y="16" width="128" height="224" fill="url(#steel)" />
+    <rect x="128" y="16" width="128" height="224" fill="url(#light)" />
+    <path d="M128 32l72 32v76c0 52-40 86-72 96-32-10-72-44-72-96V64z" fill="none" stroke="#121320" stroke-width="4" opacity="0.55" />
+    <path d="M128 32l72 32v76c0 52-40 86-72 96-32-10-72-44-72-96V64z" fill="none" stroke="#00e0ff" stroke-width="2" opacity="0.35" />
+    <path d="M160 80l24 40-24 40" stroke="#00e0ff" stroke-width="3" fill="none" opacity="0.6" />
+    <g opacity="0.25" stroke="#00e0ff" stroke-width="2">
+      <path d="M140 72l48 48" />
+      <path d="M164 68l48 48" />
+      <path d="M144 124l40 40" />
+    </g>
+    <g opacity="0.6" stroke="#d8b36f" stroke-width="3">
+      <path d="M96 64l16 16" />
+      <path d="M108 60l16 16" />
+      <path d="M84 84l32 32" />
+    </g>
+  </g>
+  <path d="M70 124h116" stroke="url(#engrave)" stroke-width="12" stroke-linecap="round" />
+  <text x="128" y="132" font-family="'Montserrat', 'Futura', sans-serif" font-size="44" text-anchor="middle" fill="#232323" opacity="0.7">CIVIL</text>
+  <text x="128" y="128" font-family="'Montserrat', 'Futura', sans-serif" font-size="44" text-anchor="middle" fill="#f4deba" letter-spacing="6">CIVIL</text>
+  <path d="M40 228h176" stroke="#151515" stroke-width="10" stroke-linecap="round" opacity="0.5" />
+  <path d="M40 220h176" stroke="#2e3156" stroke-width="6" stroke-linecap="round" opacity="0.7" />
+</svg>

--- a/assets/branding/preview-build-your-kingdom.svg
+++ b/assets/branding/preview-build-your-kingdom.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="bgCity" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0d1028" />
+      <stop offset="100%" stop-color="#2b2f77" />
+    </linearGradient>
+    <linearGradient id="sunrise" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#d8b36f" stop-opacity="0.7" />
+      <stop offset="100%" stop-color="#0d1028" stop-opacity="0" />
+    </linearGradient>
+    <linearGradient id="beamCity" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#00e0ff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#00a6c6" stop-opacity="0.1" />
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#bgCity)" />
+  <circle cx="320" cy="180" r="220" fill="url(#sunrise)" />
+  <g opacity="0.5" stroke="#00e0ff" stroke-width="2" stroke-dasharray="12 10">
+    <path d="M120 600h1040" />
+    <path d="M160 560h960" />
+    <path d="M200 520h880" />
+  </g>
+  <g transform="translate(160 240)" fill="#151830">
+    <rect x="0" y="180" width="160" height="240" rx="12" />
+    <rect x="160" y="140" width="180" height="280" rx="12" />
+    <rect x="360" y="100" width="220" height="320" rx="18" />
+    <rect x="620" y="180" width="160" height="240" rx="10" />
+    <rect x="780" y="220" width="120" height="200" rx="8" />
+    <rect x="930" y="160" width="140" height="260" rx="12" />
+  </g>
+  <g transform="translate(160 240)" fill="#1f234a">
+    <rect x="24" y="220" width="120" height="200" rx="10" />
+    <rect x="188" y="180" width="132" height="240" rx="12" />
+    <rect x="380" y="140" width="172" height="280" rx="14" />
+    <rect x="648" y="220" width="120" height="200" rx="10" />
+    <rect x="796" y="240" width="96" height="180" rx="8" />
+    <rect x="956" y="200" width="104" height="220" rx="10" />
+  </g>
+  <g transform="translate(240 220)" opacity="0.85">
+    <path d="M120 200l80-120 80 120z" fill="#d8b36f" />
+    <path d="M320 160l68-100 68 100z" fill="#f0d39d" opacity="0.7" />
+    <path d="M560 200l52-80 52 80z" fill="#d8b36f" />
+    <path d="M720 220l44-72 44 72z" fill="#c9a05c" />
+  </g>
+  <g transform="translate(200 160)" opacity="0.3" fill="#00e0ff">
+    <circle cx="120" cy="420" r="16" />
+    <circle cx="304" cy="380" r="18" />
+    <circle cx="540" cy="360" r="20" />
+    <circle cx="760" cy="420" r="14" />
+    <circle cx="920" cy="340" r="18" />
+  </g>
+  <g transform="translate(200 140)" font-family="'Orbitron', 'Montserrat', sans-serif" font-size="26" fill="#00e0ff">
+    <text x="112" y="424">Gold</text>
+    <text x="296" y="384">Iron</text>
+    <text x="532" y="364">Bread</text>
+    <text x="752" y="424">Stone</text>
+    <text x="912" y="344">Faith</text>
+  </g>
+  <path d="M140 480h1000" stroke="url(#beamCity)" stroke-width="12" opacity="0.6" />
+  <text x="1040" y="120" font-family="'Cinzel', serif" font-size="72" fill="#f0d39d" text-anchor="end">Civilisation</text>
+  <text x="1040" y="182" font-family="'Montserrat', sans-serif" font-size="32" fill="#00e0ff" text-anchor="end" letter-spacing="6">BUILD YOUR KINGDOM</text>
+  <text x="1040" y="228" font-family="'Montserrat', sans-serif" font-size="24" fill="#f0d39d" text-anchor="end">From humble village to mighty empire.</text>
+  <rect x="920" y="520" width="200" height="64" rx="32" fill="#d8b36f" opacity="0.85" />
+  <text x="1020" y="562" font-family="'Montserrat', sans-serif" font-size="24" fill="#232323" text-anchor="middle">Tap to Expand</text>
+</svg>

--- a/assets/branding/preview-epic-alliances.svg
+++ b/assets/branding/preview-epic-alliances.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="bgAlliance" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#10132c" />
+      <stop offset="100%" stop-color="#2b2f77" />
+    </linearGradient>
+    <linearGradient id="banner" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#d8b36f" />
+      <stop offset="100%" stop-color="#8c6a2f" />
+    </linearGradient>
+    <radialGradient id="centerGlow" cx="0.5" cy="0.6" r="0.6">
+      <stop offset="0%" stop-color="#00e0ff" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#00e0ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#bgAlliance)" />
+  <circle cx="640" cy="400" r="320" fill="url(#centerGlow)" />
+  <g transform="translate(160 200)" fill="#1a1d3e" opacity="0.8">
+    <path d="M0 280l160-200 80 120 120-160 120 200 120-180 120 200 120-220 120 160 80-120 120 200 80-80 40 180H0z" />
+  </g>
+  <g transform="translate(160 240)" fill="#232649">
+    <path d="M0 240l140-180 80 120 120-160 120 200 120-180 120 200 120-220 120 160 80-120 120 200 80-80 40 160H0z" />
+  </g>
+  <g transform="translate(160 220)">
+    <path d="M120 200h80v200h-80z" fill="#101326" stroke="#d8b36f" stroke-width="6" />
+    <path d="M120 200l40-80 40 80z" fill="url(#banner)" />
+    <path d="M920 200h80v200h-80z" fill="#101326" stroke="#d8b36f" stroke-width="6" />
+    <path d="M920 200l40-80 40 80z" fill="url(#banner)" />
+  </g>
+  <g transform="translate(160 220)" stroke="#00e0ff" stroke-width="3" opacity="0.55">
+    <path d="M120 320h880" />
+    <path d="M180 260l760 120" />
+    <path d="M200 360l720-120" />
+  </g>
+  <g transform="translate(160 220)" fill="#d8b36f">
+    <circle cx="120" cy="320" r="14" />
+    <circle cx="440" cy="360" r="14" />
+    <circle cx="800" cy="280" r="14" />
+    <circle cx="1000" cy="320" r="14" />
+  </g>
+  <text x="640" y="144" font-family="'Cinzel', serif" font-size="72" fill="#f0d39d" text-anchor="middle">Epic Alliances</text>
+  <text x="640" y="196" font-family="'Montserrat', sans-serif" font-size="30" fill="#00e0ff" text-anchor="middle">Unite or be conquered.</text>
+  <text x="640" y="248" font-family="'Montserrat', sans-serif" font-size="22" fill="#f0d39d" text-anchor="middle">Banner-waving armies merging under one flag.</text>
+</svg>

--- a/assets/branding/preview-on-the-world-chain.svg
+++ b/assets/branding/preview-on-the-world-chain.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
+  <defs>
+    <radialGradient id="coinGlow" cx="0.5" cy="0.5" r="0.6">
+      <stop offset="0%" stop-color="#f5dfb5" />
+      <stop offset="60%" stop-color="#d8b36f" />
+      <stop offset="100%" stop-color="#8c6a2f" />
+    </radialGradient>
+    <radialGradient id="bgChain" cx="0.7" cy="0.3" r="1">
+      <stop offset="0%" stop-color="#1a1d3f" />
+      <stop offset="100%" stop-color="#05060f" />
+    </radialGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#bgChain)" />
+  <g opacity="0.2" stroke="#00e0ff" stroke-width="2">
+    <path d="M200 80l880 560" />
+    <path d="M240 40l880 560" />
+    <path d="M160 120l880 560" />
+    <path d="M120 160l880 560" />
+  </g>
+  <g opacity="0.2" stroke="#00e0ff" stroke-width="1">
+    <path d="M120 80h1040" />
+    <path d="M120 160h1040" />
+    <path d="M120 240h1040" />
+    <path d="M120 320h1040" />
+    <path d="M120 400h1040" />
+    <path d="M120 480h1040" />
+    <path d="M120 560h1040" />
+    <path d="M120 640h1040" />
+  </g>
+  <g transform="translate(640 360)">
+    <circle cx="0" cy="0" r="220" fill="#0f1228" opacity="0.65" />
+    <circle cx="0" cy="0" r="200" fill="url(#coinGlow)" />
+    <circle cx="0" cy="0" r="152" fill="#f5dfb5" opacity="0.55" />
+    <circle cx="0" cy="0" r="144" fill="#101326" />
+    <circle cx="0" cy="0" r="120" fill="none" stroke="#d8b36f" stroke-width="12" />
+    <circle cx="0" cy="0" r="90" fill="none" stroke="#00e0ff" stroke-width="6" stroke-dasharray="20 16" />
+    <path d="M0-88c48 0 88 40 88 88s-40 88-88 88-88-40-88-88 40-88 88-88z" fill="#0f122c" />
+    <path d="M0-66c34 0 62 28 62 62s-28 62-62 62-62-28-62-62 28-62 62-62z" fill="#232649" />
+    <path d="M0-44c20 0 36 16 36 36s-16 36-36 36-36-16-36-36 16-36 36-36z" fill="#0f122c" />
+    <circle cx="0" cy="0" r="26" fill="#00e0ff" opacity="0.8" />
+    <circle cx="0" cy="0" r="10" fill="#0f122c" />
+    <g opacity="0.8" stroke="#d8b36f" stroke-width="6" stroke-linecap="round">
+      <path d="M-120 0h240" />
+      <path d="M0-120v240" />
+    </g>
+    <g opacity="0.5" stroke="#00e0ff" stroke-width="4">
+      <path d="M-120-120L120 120" />
+      <path d="M120-120L-120 120" />
+    </g>
+  </g>
+  <g opacity="0.35" stroke="#00e0ff" stroke-width="2">
+    <path d="M420 140l40 40" />
+    <path d="M820 540l40 40" />
+    <path d="M920 200l40 40" />
+    <path d="M320 520l40 40" />
+  </g>
+  <text x="940" y="140" font-family="'Cinzel', serif" font-size="70" fill="#f0d39d" text-anchor="end">On the World Chain</text>
+  <text x="940" y="192" font-family="'Montserrat', sans-serif" font-size="30" fill="#00e0ff" text-anchor="end">Own your progress, on-chain.</text>
+  <text x="940" y="240" font-family="'Montserrat', sans-serif" font-size="22" fill="#f0d39d" text-anchor="end">Civilisation x World App MiniKit</text>
+</svg>

--- a/assets/branding/preview-rule-through-strategy.svg
+++ b/assets/branding/preview-rule-through-strategy.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="bgBattle" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#161b3e" />
+      <stop offset="100%" stop-color="#232323" />
+    </linearGradient>
+    <linearGradient id="gridGlow" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#00e0ff" stop-opacity="0.25" />
+      <stop offset="100%" stop-color="#00e0ff" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#bgBattle)" />
+  <g opacity="0.5" stroke="#00e0ff" stroke-width="1">
+    <path d="M0 440h1280" />
+    <path d="M0 500h1280" />
+    <path d="M0 560h1280" />
+    <path d="M0 620h1280" />
+    <path d="M120 360v360" />
+    <path d="M240 360v360" />
+    <path d="M360 360v360" />
+    <path d="M480 360v360" />
+    <path d="M600 360v360" />
+    <path d="M720 360v360" />
+    <path d="M840 360v360" />
+    <path d="M960 360v360" />
+    <path d="M1080 360v360" />
+  </g>
+  <rect x="0" y="360" width="1280" height="360" fill="url(#gridGlow)" />
+  <g transform="translate(120 200)">
+    <path d="M0 220l140-120 120 80 140-160 120 120 160-120 120 180 140-60" fill="none" stroke="#d8b36f" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M0 220l140-120 120 80 140-160 120 120 160-120 120 180 140-60" fill="none" stroke="#00e0ff" stroke-width="2" stroke-dasharray="10 12" />
+    <g fill="#d8b36f">
+      <circle cx="0" cy="220" r="14" />
+      <circle cx="140" cy="100" r="12" />
+      <circle cx="260" cy="180" r="12" />
+      <circle cx="400" cy="20" r="12" />
+      <circle cx="520" cy="140" r="12" />
+      <circle cx="680" cy="20" r="12" />
+      <circle cx="800" cy="200" r="12" />
+      <circle cx="940" cy="140" r="12" />
+    </g>
+    <g fill="#00e0ff" opacity="0.5">
+      <circle cx="0" cy="220" r="26" />
+      <circle cx="140" cy="100" r="24" />
+      <circle cx="260" cy="180" r="24" />
+      <circle cx="400" cy="20" r="24" />
+      <circle cx="520" cy="140" r="24" />
+      <circle cx="680" cy="20" r="24" />
+      <circle cx="800" cy="200" r="24" />
+      <circle cx="940" cy="140" r="24" />
+    </g>
+  </g>
+  <g transform="translate(180 420)" font-family="'Montserrat', sans-serif" font-size="24" fill="#d8b36f">
+    <text x="-40" y="0">Infantry</text>
+    <text x="120" y="-60">Archers</text>
+    <text x="280" y="20">Cavalry</text>
+    <text x="440" y="-120">Siege</text>
+    <text x="560" y="0">Scout</text>
+    <text x="720" y="-120">Mage</text>
+    <text x="840" y="60">Allies</text>
+    <text x="980" y="-20">Warden</text>
+  </g>
+  <g transform="translate(160 160)">
+    <rect x="760" y="-40" width="280" height="160" rx="16" fill="#0f122c" stroke="#00e0ff" stroke-width="3" opacity="0.8" />
+    <text x="900" y="4" font-family="'Montserrat', sans-serif" font-size="28" fill="#00e0ff" text-anchor="middle">Battle Planner</text>
+    <text x="900" y="44" font-family="'Montserrat', sans-serif" font-size="20" fill="#f0d39d" text-anchor="middle">Deploy units with precision</text>
+    <text x="900" y="84" font-family="'Montserrat', sans-serif" font-size="18" fill="#f0d39d" text-anchor="middle">Plan. Conquer. Expand.</text>
+  </g>
+  <text x="1120" y="120" font-family="'Cinzel', serif" font-size="68" fill="#f0d39d" text-anchor="end">Rule Through Strategy</text>
+  <text x="1120" y="172" font-family="'Montserrat', sans-serif" font-size="30" fill="#00e0ff" text-anchor="end">Plan. Conquer. Expand.</text>
+</svg>

--- a/assets/branding/preview-your-legacy-awaits.svg
+++ b/assets/branding/preview-your-legacy-awaits.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="bgLegacy" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#05060f" />
+      <stop offset="100%" stop-color="#1a1d3f" />
+    </linearGradient>
+    <linearGradient id="horizon" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#d8b36f" stop-opacity="0.65" />
+      <stop offset="100%" stop-color="#05060f" stop-opacity="0" />
+    </linearGradient>
+    <radialGradient id="heroGlow" cx="0.5" cy="0.6" r="0.7">
+      <stop offset="0%" stop-color="#00e0ff" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#00e0ff" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="cape" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#2b2f77" />
+      <stop offset="100%" stop-color="#10132c" />
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#bgLegacy)" />
+  <rect x="0" y="320" width="1280" height="200" fill="#0b0d18" />
+  <rect x="0" y="220" width="1280" height="180" fill="url(#horizon)" />
+  <circle cx="640" cy="400" r="320" fill="url(#heroGlow)" />
+  <g transform="translate(0 420)" fill="#0f1228" opacity="0.8">
+    <path d="M0 120l120-60 140 80 160-120 140 80 160-120 160 100 160-140 120 120 120-80v200H0z" />
+  </g>
+  <g transform="translate(0 440)" fill="#151830" opacity="0.7">
+    <path d="M0 100l120-60 140 80 160-120 140 80 160-120 160 100 160-140 120 120 120-80v180H0z" />
+  </g>
+  <g transform="translate(540 220)">
+    <path d="M80 280l-40 120h160l-40-120z" fill="#1a1d3f" stroke="#00e0ff" stroke-width="4" />
+    <path d="M100 160h40l80 160H20z" fill="#0f1228" stroke="#00e0ff" stroke-width="3" />
+    <path d="M120 0l60 120-60 80-60-80z" fill="#d8b36f" />
+    <path d="M120 0l-12 40 12 12 12-12z" fill="#f5dfb5" />
+    <path d="M60 180l60 40 60-40v160H60z" fill="#0d1028" />
+    <path d="M60 200l-60 140 120-60z" fill="url(#cape)" opacity="0.9" />
+    <path d="M180 200l60 140-120-60z" fill="url(#cape)" opacity="0.7" />
+    <path d="M100 120h40l-20 40z" fill="#8c6a2f" />
+    <path d="M120 220l40-20 20 40-60 20-60-20 20-40z" fill="#d8b36f" opacity="0.85" />
+    <path d="M120 240l40 40-40 40-40-40z" fill="#101326" stroke="#00e0ff" stroke-width="2" />
+  </g>
+  <g opacity="0.4" stroke="#00e0ff" stroke-width="2" stroke-dasharray="10 14">
+    <path d="M120 520h1040" />
+    <path d="M160 560h960" />
+    <path d="M200 600h880" />
+  </g>
+  <text x="640" y="140" font-family="'Cinzel', serif" font-size="76" fill="#f0d39d" text-anchor="middle">Your Legacy Awaits</text>
+  <text x="640" y="192" font-family="'Montserrat', sans-serif" font-size="32" fill="#00e0ff" text-anchor="middle">CIVIL — Build a world that remembers you.</text>
+  <text x="640" y="236" font-family="'Montserrat', sans-serif" font-size="22" fill="#f0d39d" text-anchor="middle">Hero with sword overlooking a vast digital-medieval landscape.</text>
+</svg>


### PR DESCRIPTION
## Summary
- add three app icon explorations that blend medieval motifs with cyan blockchain glow
- add five hero/store preview illustrations covering city building, strategy, alliances, and legacy themes
- document asset contents and motion ideas for future production

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e53408590483208c2604ed56e1a596