### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -34,6 +34,10 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
       - name: Setup Bun.js
         uses: oven-sh/setup-bun@v2
 
@@ -44,9 +48,23 @@ jobs:
         env:
           VITE_PUBLIC_APP_ID: ${{ vars.WORLD_APP_ID }}
           VITE_PUBLIC_CONTRACT_ADDRESS: ${{ vars.WORLD_CONTRACT_ADDRESS }}
+          VITE_BASE_PATH: ${{ steps.pages.outputs.base_path }}
+          NEXT_PUBLIC_BASE_PATH: ${{ steps.pages.outputs.base_path }}
         run: bun run build
 
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v4
         with:
           path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- configure GitHub Pages during the build to expose the deployment base path
- pass the resolved base path into the build environment and deploy the artifact to GitHub Pages

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e55b88eaf88320ba274055480f945a