### PR TITLE
Fix Codex action inputs in AI workflows

### DIFF
--- a/.github/workflows/ai-autofix.yml
+++ b/.github/workflows/ai-autofix.yml
@@ -88,13 +88,13 @@ jobs:
         uses: openai/codex-action@v1
         id: codex
         with:
-          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt: >-
             You are working in a Bun + TypeScript monorepo with Foundry contracts and GitHub Actions.
             Read the repository, run the Bun lint and build scripts as well as `forge test`,
             identify the minimal change needed to make these commands succeed, implement only that change, and stop.
             Do not refactor unrelated code or files. Keep changes small and surgical.
-          codex_args: '["--config","sandbox_mode=\"workspace-write\"","--config","allow_network=\"false\""]'
+          codex-args: '["--config","sandbox_mode=\"workspace-write\"","--config","allow_network=\"false\""]'
 
       - name: Setup Foundry
         if: steps.ai-inputs.outputs.enabled == 'true'

--- a/.github/workflows/ai-document.yml
+++ b/.github/workflows/ai-document.yml
@@ -75,14 +75,14 @@ jobs:
         id: codex
         uses: openai/codex-action@v1
         with:
-          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt: >-
             You are the documentation maintainer for the Civilisation DApp repository.
             Review the existing content under the docs/ directory and the README.
             Identify missing or unclear documentation topics related to the latest changes in this branch and add or improve Markdown files under docs/ to cover them.
             Keep all documentation in English, focus on accuracy, and do not modify source code outside of docs/ or README.md.
             When updating files, include navigation links where helpful.
-          codex_args: '["--config","sandbox_mode=\"workspace-write\"","--config","allow_network=\"false\""]'
+          codex-args: '["--config","sandbox_mode=\"workspace-write\"","--config","allow_network=\"false\""]'
 
       - name: Detect changes
         id: changes


### PR DESCRIPTION
## Summary
- update the AI autofix workflow to pass `openai-api-key` and `codex-args` to the Codex action
- correct the AI documentation workflow to use the Codex action input names expected by openai/codex-action

## Testing
- not run (workflow YAML change only)


------
https://chatgpt.com/codex/tasks/task_e_68e568fd5f3083209d8b70a972527f44