### PR TITLE
Restore scrolling while preserving bounce guard

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -342,7 +342,8 @@ body {
 body {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   touch-action: manipulation;


### PR DESCRIPTION
## Summary
- allow the document body to scroll again by replacing overflow hidden with axis-specific rules
- keep the overscroll bounce guard in place to avoid browser bounce while restoring usability

## Testing
- bun run lint *(fails: missing eslint-config-prettier package in environment)*
- bun run test:web *(fails: vitest command not available in environment)*
- bun run test:contracts *(fails: forge command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e579778b8c8320a11211b239d130e8